### PR TITLE
Initialize database connection in init script

### DIFF
--- a/includes/init_db.php
+++ b/includes/init_db.php
@@ -1,6 +1,9 @@
 <?php
 require_once 'database.php';
 
+// Establish a single database connection for this script
+$db = get_db_connection();
+
 try {
     // Create users table with updated schema
     $db->exec("CREATE TABLE IF NOT EXISTS users (


### PR DESCRIPTION
## Summary
- open the DB connection at the start of `includes/init_db.php`

## Testing
- `php -l includes/init_db.php`
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_b_685c6c5f8f348322918f40033d3f45a9