### PR TITLE
Add simple contact form

### DIFF
--- a/contact.php
+++ b/contact.php
@@ -1,0 +1,50 @@
+<?php
+session_start();
+?>
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <title>تماس با ما</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.rtl.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <h1 class="mb-4 text-center">تماس با ما</h1>
+    <?php if (isset($_GET['success'])): ?>
+        <div class="alert alert-success text-center">پیام شما با موفقیت ارسال شد.</div>
+    <?php elseif (isset($_GET['error'])): ?>
+        <div class="alert alert-danger text-center">
+            <?php
+            switch ($_GET['error']) {
+                case 'missing':
+                    echo 'لطفا تمام فیلدها را پر کنید.';
+                    break;
+                case 'invalid_email':
+                    echo 'ایمیل نامعتبر است.';
+                    break;
+                default:
+                    echo 'خطایی رخ داده است. لطفا دوباره تلاش کنید.';
+            }
+            ?>
+        </div>
+    <?php endif; ?>
+    <form action="includes/contact_handler.php" method="post" class="mx-auto" style="max-width:600px;">
+        <div class="mb-3">
+            <label class="form-label">نام</label>
+            <input type="text" name="name" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">ایمیل</label>
+            <input type="email" name="email" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">پیام</label>
+            <textarea name="message" class="form-control" rows="5" required></textarea>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">ارسال</button>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/includes/contact_handler.php
+++ b/includes/contact_handler.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/database.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $message = trim($_POST['message'] ?? '');
+
+    if ($name === '' || $email === '' || $message === '') {
+        header('Location: ../contact.php?error=missing');
+        exit;
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        header('Location: ../contact.php?error=invalid_email');
+        exit;
+    }
+
+    try {
+        $pdo = get_db_connection();
+        $pdo->exec("CREATE TABLE IF NOT EXISTS contact_messages (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255) NOT NULL,
+            email VARCHAR(255) NOT NULL,
+            message TEXT NOT NULL,
+            submitted_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+        $stmt = $pdo->prepare('INSERT INTO contact_messages (name, email, message) VALUES (?, ?, ?)');
+        $stmt->execute([$name, $email, $message]);
+        // You could also send an email here using the mail() function
+        header('Location: ../contact.php?success=1');
+        exit;
+    } catch (Exception $e) {
+        header('Location: ../contact.php?error=server');
+        exit;
+    }
+}
+
+header('Location: ../contact.php');


### PR DESCRIPTION
## Summary
- create a `contact.php` page with a working form
- add `includes/contact_handler.php` to store submitted messages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c76019e208322952c11d38c7a4694