### PR TITLE
Add about page and extend homepage

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>درباره ما</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.rtl.min.css">
+    <link href="https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/font-face.css" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/main.css">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <section id="about" class="py-5 bg-white rounded">
+            <div class="container">
+                <h2 class="text-center mb-4">درباره ما</h2>
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <p>سیستم مدیریت سلامت ما با هدف ارائه خدمات بهداشتی و درمانی با کیفیت و قابل دسترس برای همه طراحی شده است.</p>
+                    </div>
+                    <div class="col-md-6">
+                        <p>با استفاده از فناوری‌های پیشرفته، ما ارتباط بین بیماران و پزشکان را تسهیل می‌کنیم.</p>
+                    </div>
+                </div>
+                <p class="mt-3">ما متعهد به بهبود کیفیت زندگی کاربران با ارائه ابزارهای پیشرفته سلامت دیجیتال هستیم.</p>
+                <p>مزایای استفاده از این پلتفرم شامل دسترسی آسان به پرونده‌های سلامت، ارتباط سریع با پزشکان و دریافت توصیه‌های شخصی‌سازی شده است.</p>
+            </div>
+        </section>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -30,7 +30,7 @@ $latest_articles = get_rows(
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link" href="#about">درباره ما</a>
+                        <a class="nav-link" href="about.php">درباره ما</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="#services">خدمات</a>
@@ -39,7 +39,7 @@ $latest_articles = get_rows(
                         <a class="nav-link" href="articles/articles.php">مقالات سلامت</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="#contact">تماس با ما</a>
+                        <a class="nav-link" href="contact.php">تماس با ما</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link" href="login.php">ورود</a>
@@ -58,6 +58,25 @@ $latest_articles = get_rows(
             <a href="login.php" class="btn btn-primary btn-lg">شروع کنید</a>
         </div>
     </div>
+
+    <!-- Additional Content Below Hero -->
+    <section class="py-5" id="intro-extra">
+        <div class="container">
+            <div class="row mb-4">
+                <div class="col-md-4 mb-3">
+                    <img src="https://source.unsplash.com/featured/?medical" class="img-fluid rounded" alt="Medical">
+                </div>
+                <div class="col-md-4 mb-3">
+                    <img src="https://source.unsplash.com/featured/?doctor" class="img-fluid rounded" alt="Doctor">
+                </div>
+                <div class="col-md-4 mb-3">
+                    <img src="https://source.unsplash.com/featured/?hospital" class="img-fluid rounded" alt="Hospital">
+                </div>
+            </div>
+            <p class="text-center">تیم ما همواره تلاش می‌کند تا با ارائه ابزارهای نوین، تجربه‌ای امن و کارآمد برای مدیریت سلامت شما فراهم کند.</p>
+            <p class="text-center">با مرور مطالب و خدمات ما، می‌توانید آگاهی بیشتری نسبت به پیشگیری و درمان بیماری‌ها به دست آورید.</p>
+        </div>
+    </section>
 
     <!-- About Section -->
     <section id="about" class="py-5">


### PR DESCRIPTION
## Summary
- create `about.php` as standalone about page with extra mission info
- update navigation links in `index.php`
- add extra images and text after hero section on homepage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cef1f42708322816091c3c4335b8b