### PR TITLE
Enhance admin registration UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ To include these icons in a PHP page, add the following line within the `<head>`
 <link rel="stylesheet" href="/assets/fontawesome/css/all.min.css">
 ```
 
+## External Images
+
+The admin registration page loads an icon from the Bootstrap Icons repository:
+
+```
+https://raw.githubusercontent.com/twbs/icons/main/icons/person-gear.svg
+```
+
+If you prefer to keep assets locally, download the file from the link above and
+place it in your project (e.g. under `assets/images`). Then update the `<img>`
+tag in `dashboard/admin_register.php` to reference the local path.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/dashboard/admin_register.php
+++ b/dashboard/admin_register.php
@@ -16,34 +16,47 @@ require_role('admin');
 </head>
 <body class="bg-light p-4">
 <div class="container">
-    <h3 class="mb-4">افزودن مدیر جدید</h3>
-    <?php if (isset($_GET['success'])): ?>
-        <div class="alert alert-success">مدیر جدید با موفقیت ثبت شد</div>
-    <?php elseif (isset($_GET['error'])): ?>
-        <div class="alert alert-danger">خطا در ثبت مدیر جدید</div>
-    <?php endif; ?>
+    <div class="row justify-content-center">
+        <div class="col-md-8 col-lg-6">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <div class="text-center mb-4">
+                        <img src="https://raw.githubusercontent.com/twbs/icons/main/icons/person-gear.svg"
+                             alt="Admin icon" class="mb-2" style="width: 80px;">
+                        <h3 class="card-title">افزودن مدیر جدید</h3>
+                    </div>
 
-    <form action="admin_register_handler.php" method="POST" class="row g-3">
-        <div class="col-md-6">
-            <label class="form-label">نام کامل</label>
-            <input type="text" name="name" class="form-control" required>
+                    <?php if (isset($_GET['success'])): ?>
+                        <div class="alert alert-success">مدیر جدید با موفقیت ثبت شد</div>
+                    <?php elseif (isset($_GET['error'])): ?>
+                        <div class="alert alert-danger">خطا در ثبت مدیر جدید</div>
+                    <?php endif; ?>
+
+                    <form action="admin_register_handler.php" method="POST" class="row g-3">
+                        <div class="col-md-6">
+                            <label class="form-label">نام کامل</label>
+                            <input type="text" name="name" class="form-control" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">شماره تلفن</label>
+                            <input type="tel" name="phone" class="form-control" pattern="^09\d{9}$" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">کد ملی</label>
+                            <input type="text" name="national_id" class="form-control" pattern="^\d{10}$" required>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">رمز عبور</label>
+                            <input type="password" name="password" class="form-control" required>
+                        </div>
+                        <div class="col-12">
+                            <button type="submit" class="btn btn-success">ثبت مدیر جدید</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
         </div>
-        <div class="col-md-6">
-            <label class="form-label">شماره تلفن</label>
-            <input type="tel" name="phone" class="form-control" pattern="^09\d{9}$" required>
-        </div>
-        <div class="col-md-6">
-            <label class="form-label">کد ملی</label>
-            <input type="text" name="national_id" class="form-control" pattern="^\d{10}$" required>
-        </div>
-        <div class="col-md-6">
-            <label class="form-label">رمز عبور</label>
-            <input type="password" name="password" class="form-control" required>
-        </div>
-        <div class="col-12">
-            <button type="submit" class="btn btn-success">ثبت مدیر جدید</button>
-        </div>
-    </form>
+    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a header card with an external icon in the admin registration form
- describe how to use the external image in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685cf1109cc083229ad991b17453f347