### PR TITLE
Add database config constants

### DIFF
--- a/dashboard/admin_handler.php
+++ b/dashboard/admin_handler.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once '../includes/config.php';
 require_once '../includes/database.php';
 require_once '../includes/auth_handler.php';
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -1,0 +1,11 @@
+<?php
+// Database configuration
+
+define('DB_HOST', 'localhost');
+
+define('DB_USER', 'root');
+
+define('DB_PASS', '');
+
+define('DB_NAME', 'health_project');
+

--- a/includes/database.php
+++ b/includes/database.php
@@ -1,7 +1,10 @@
 <?php
+require_once __DIR__ . '/config.php';
+
 function get_db_connection() {
     try {
-        $pdo = new PDO("mysql:host=localhost;dbname=health_project;charset=utf8", "root", "");
+        $dsn = sprintf('mysql:host=%s;dbname=%s;charset=utf8', DB_HOST, DB_NAME);
+        $pdo = new PDO($dsn, DB_USER, DB_PASS);
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
         return $pdo;


### PR DESCRIPTION
## Summary
- create `includes/config.php` with DB config constants
- include new config in `database.php` and `admin_handler.php`
- update `get_db_connection()` to use the constants

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cf83e5bdc8322870b6a8d68623244