### PR TITLE
Replace deprecated sanitize filter

### DIFF
--- a/articles/article_handler.php
+++ b/articles/article_handler.php
@@ -46,7 +46,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         switch ($_POST['action']) {
             case 'create':
                 // Validate inputs
-                $title = filter_var($_POST['title'], FILTER_SANITIZE_STRING);
+                $title = strip_tags(filter_var($_POST['title'], FILTER_UNSAFE_RAW));
                 $content = $_POST['content']; // Allow HTML content from TinyMCE
                 
                 if (empty($title) || mb_strlen($title) < 5) {
@@ -82,7 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             case 'edit':
                 // Validate inputs
                 $article_id = filter_var($_POST['article_id'], FILTER_SANITIZE_NUMBER_INT);
-                $title = filter_var($_POST['title'], FILTER_SANITIZE_STRING);
+                $title = strip_tags(filter_var($_POST['title'], FILTER_UNSAFE_RAW));
                 $content = $_POST['content']; // Allow HTML content from TinyMCE
                 
                 if (empty($title) || mb_strlen($title) < 5) {

--- a/dashboard/admin_handler.php
+++ b/dashboard/admin_handler.php
@@ -88,8 +88,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             
         case 'update_settings':
             // Example of updating system settings
-            $site_name = filter_var($_POST['site_name'], FILTER_SANITIZE_STRING);
-            $contact_phone = filter_var($_POST['contact_phone'], FILTER_SANITIZE_STRING);
+            $site_name = strip_tags(filter_var($_POST['site_name'], FILTER_UNSAFE_RAW));
+            $contact_phone = strip_tags(filter_var($_POST['contact_phone'], FILTER_UNSAFE_RAW));
             
             $updates = [
                 "UPDATE settings SET value = ? WHERE name = 'site_name'",

--- a/dashboard/doctor_handler.php
+++ b/dashboard/doctor_handler.php
@@ -72,7 +72,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     switch ($_POST['action']) {
         case 'send_message':
             $patient_id = filter_var($_POST['patient_id'], FILTER_SANITIZE_NUMBER_INT);
-            $content = filter_var($_POST['content'], FILTER_SANITIZE_STRING);
+            $content = strip_tags(filter_var($_POST['content'], FILTER_UNSAFE_RAW));
             
             // Verify this patient is assigned to the current doctor
             $is_assigned = get_row(
@@ -107,7 +107,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             
         case 'update_patient_status':
             $patient_id = filter_var($_POST['patient_id'], FILTER_SANITIZE_NUMBER_INT);
-            $status = filter_var($_POST['status'], FILTER_SANITIZE_STRING);
+            $status = strip_tags(filter_var($_POST['status'], FILTER_UNSAFE_RAW));
             
             // Verify this patient is assigned to the current doctor
             $is_assigned = get_row(
@@ -136,7 +136,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             
         case 'add_note':
             $patient_id = filter_var($_POST['patient_id'], FILTER_SANITIZE_NUMBER_INT);
-            $note = filter_var($_POST['note'], FILTER_SANITIZE_STRING);
+            $note = strip_tags(filter_var($_POST['note'], FILTER_UNSAFE_RAW));
             
             // Verify this patient is assigned to the current doctor
             $is_assigned = get_row(
@@ -165,7 +165,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         case 'add_prescription':
             $patient_id = filter_var($_POST['patient_id'], FILTER_SANITIZE_NUMBER_INT);
-            $content = filter_var($_POST['prescription'], FILTER_SANITIZE_STRING);
+            $content = strip_tags(filter_var($_POST['prescription'], FILTER_UNSAFE_RAW));
 
             $is_assigned = get_row(
                 "SELECT 1 FROM doctor_patient WHERE doctor_id = ? AND patient_id = ?",

--- a/dashboard/patient_handler.php
+++ b/dashboard/patient_handler.php
@@ -10,10 +10,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Sanitize and validate inputs
     $user_id = $_SESSION['user_id'];
     $temperature = filter_var($_POST['temperature'], FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
-    $blood_pressure = filter_var($_POST['blood_pressure'], FILTER_SANITIZE_STRING);
-    $blood_sugar = filter_var($_POST['blood_sugar'], FILTER_SANITIZE_STRING);
-    $energy_level = filter_var($_POST['energy_level'], FILTER_SANITIZE_STRING);
-    $note = filter_var($_POST['note'], FILTER_SANITIZE_STRING);
+    $blood_pressure = strip_tags(filter_var($_POST['blood_pressure'], FILTER_UNSAFE_RAW));
+    $blood_sugar = strip_tags(filter_var($_POST['blood_sugar'], FILTER_UNSAFE_RAW));
+    $energy_level = strip_tags(filter_var($_POST['energy_level'], FILTER_UNSAFE_RAW));
+    $note = strip_tags(filter_var($_POST['note'], FILTER_UNSAFE_RAW));
 
     // Validate temperature
     if ($temperature < 35 || $temperature > 42) {

--- a/dashboard/submit_review.php
+++ b/dashboard/submit_review.php
@@ -7,7 +7,7 @@ require_role('patient');
 
 $doctor_id = filter_var($_POST['doctor_id'] ?? null, FILTER_SANITIZE_NUMBER_INT);
 $rating = filter_var($_POST['rating'] ?? null, FILTER_SANITIZE_NUMBER_INT);
-$comment = filter_var($_POST['comment'] ?? '', FILTER_SANITIZE_STRING);
+$comment = strip_tags(filter_var($_POST['comment'] ?? '', FILTER_UNSAFE_RAW));
 
 if (!$doctor_id || !$rating || $rating < 1 || $rating > 5) {
     header('Location: patient.php');


### PR DESCRIPTION
## Summary
- stop using deprecated `FILTER_SANITIZE_STRING`
- apply `FILTER_UNSAFE_RAW` then strip HTML tags

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685cf83f85288322905b3a359746ae4f